### PR TITLE
feat: simplify user-facing error messages

### DIFF
--- a/cogs/MemberStats.py
+++ b/cogs/MemberStats.py
@@ -149,8 +149,12 @@ class MemberStats(commands.Cog):
                 mention_author=False,
             )
         except discord.HTTPException as e:
+            logging.error(
+                f"Error while creating or updating the channel: {e}",
+                exc_info=True,
+            )
             await ctx.reply(
-                f"Discord error while creating or updating the channel: {e}",
+                "I couldn't set up the channel. Please try again later.",
                 mention_author=False,
             )
         except Exception as e:
@@ -159,7 +163,7 @@ class MemberStats(commands.Cog):
                 f"Unexpected error in setup_member_count for guild '{guild.name}' ({guild.id}): {e}"
             )
             await ctx.reply(
-                "An unexpected error occurred. Check logs for details.",
+                "Something went wrong while setting up the member count. Please try again later.",
                 mention_author=False,
             )
 
@@ -184,7 +188,7 @@ class MemberStats(commands.Cog):
         else:
             logging.error(f"setup_member_count_error: {error}", exc_info=True)
             await ctx.reply(
-                "There was an error running that command. Check logs for details.",
+                "I couldn't run that command right now. Please try again later.",
                 mention_author=False,
             )
 
@@ -229,8 +233,12 @@ class MemberStats(commands.Cog):
                 mention_author=False,
             )
         except discord.HTTPException as e:
+            logging.error(
+                f"Error while updating the channel name: {e}", exc_info=True
+            )
             await ctx.reply(
-                f"Discord error while updating the channel: {e}", mention_author=False
+                "I ran into a problem while updating the channel. Please try again later.",
+                mention_author=False,
             )
         except Exception as e:
             logging.error(
@@ -240,7 +248,7 @@ class MemberStats(commands.Cog):
                 f"Unexpected error in refresh_member_count for guild '{guild.name}' ({guild.id}): {e}"
             )
             await ctx.reply(
-                "An unexpected error occurred. Check logs for details.",
+                "Something went wrong while refreshing the member count. Please try again later.",
                 mention_author=False,
             )
 
@@ -280,8 +288,12 @@ class MemberStats(commands.Cog):
                 )
                 return
             except discord.HTTPException as e:
+                logging.error(
+                    f"Error while deleting member count channel: {e}",
+                    exc_info=True,
+                )
                 await ctx.reply(
-                    f"Discord error while deleting the channel: {e}",
+                    "I ran into a problem while deleting that channel. Please try again later.",
                     mention_author=False,
                 )
                 return

--- a/cogs/custom_embed.py
+++ b/cogs/custom_embed.py
@@ -215,7 +215,9 @@ class ContentModal(discord.ui.Modal, title="Write your embed"):
             logging.error(f"ContentModal.on_submit error: {e}")
             audit_log(f"Error sending embed: {e}")
             error = make_embed(
-                "Error", f"Unexpected error:\n`{e}`", discord.Color.red()
+                "Error",
+                "Something went wrong while sending your embed. Please try again later.",
+                discord.Color.red(),
             )
             await interaction.response.send_message(embed=error, ephemeral=True)
 
@@ -287,7 +289,9 @@ class HexContentModal(discord.ui.Modal, title="Custom HEX Embed"):
             logging.error(f"HexContentModal.on_submit error: {e}")
             audit_log(f"Error sending custom embed: {e}")
             error = make_embed(
-                "Error", f"Unexpected error:\n`{e}`", discord.Color.red()
+                "Error",
+                "Something went wrong while sending your embed. Please try again later.",
+                discord.Color.red(),
             )
             await interaction.response.send_message(embed=error, ephemeral=True)
 
@@ -335,7 +339,9 @@ class CustomEmbed(commands.Cog):
             logging.error(f"Error in /sendembed: {e}")
             audit_log(f"Unexpected error in /sendembed: {e}")
             error = make_embed(
-                "Error", f"Unexpected error:\n`{e}`", discord.Color.red()
+                "Error",
+                "Something went wrong while starting the embed maker. Please try again later.",
+                discord.Color.red(),
             )
             await interaction.response.send_message(embed=error, ephemeral=True)
 

--- a/cogs/scrape.py
+++ b/cogs/scrape.py
@@ -87,7 +87,7 @@ class Scrape(commands.Cog):
             )
             error_embed = discord.Embed(
                 title="Error",
-                description=f"An error occurred during scraping:\n`{e}`",
+                description="Something went wrong while checking the website. Please try again later.",
                 color=discord.Color.red(),
             )
             await interaction.followup.send(embed=error_embed)
@@ -378,7 +378,7 @@ class Scrape(commands.Cog):
                     logging.error(f"Failed to create thread '{thread_title}': {e}")
                     error_embed = discord.Embed(
                         title="Error",
-                        description=f"Failed to create thread '{thread_title}': `{e}`",
+                        description=f"I couldn't create the thread '{thread_title}'. Please try again later.",
                         color=discord.Color.red(),
                     )
                     await interaction.followup.send(embed=error_embed)
@@ -546,7 +546,7 @@ class Scrape(commands.Cog):
                     )
                     error_embed = discord.Embed(
                         title="Error",
-                        description=f"Failed to create scheduled event '{event_name}': `{e}`",
+                        description=f"I couldn't create the event '{event_name}'. Please try again later.",
                         color=discord.Color.red(),
                     )
                     await interaction.followup.send(embed=error_embed)

--- a/cogs/sticky.py
+++ b/cogs/sticky.py
@@ -144,7 +144,11 @@ class HexContentModal(discord.ui.Modal, title="Custom HEX Sticky"):
             )
         except Exception as e:
             logging.error(f"HexContentModal failed: {e}")
-            err = make_embed("Error", f"Unexpected error:\n`{e}`", discord.Color.red())
+            err = make_embed(
+                "Error",
+                "Something went wrong while setting the sticky message. Please try again later.",
+                discord.Color.red(),
+            )
             return await interaction.response.send_message(embed=err, ephemeral=True)
 
 


### PR DESCRIPTION
## Summary
- rephrase member count command errors to use friendly language
- streamline embed maker errors so users see simple explanations
- soften website scraping and sticky message errors for clarity

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898ac570d54832e9b922af037f1b7f2