### PR TITLE
Use embeds for bot feedback

### DIFF
--- a/cogs/CustomEmbedMessages.py
+++ b/cogs/CustomEmbedMessages.py
@@ -330,9 +330,11 @@ class CustomEmbed(commands.Cog):
                 return
 
             view = ColourPickView(channel)
-            # *** Plain-text prompt here ***
+            # *** Send prompt as an embed ***
             await interaction.response.send_message(
-                "Choose a colour for your embed:", view=view, ephemeral=True
+                embed=discord.Embed(description="Choose a colour for your embed:"),
+                view=view,
+                ephemeral=True,
             )
             audit_log(f"{interaction.user} invoked /sendembed in #{channel.name}.")
         except Exception as e:

--- a/cogs/Levelling.py
+++ b/cogs/Levelling.py
@@ -711,7 +711,10 @@ class LevelSystem(commands.Cog):
         try:
             if not interaction.guild:
                 return await interaction.response.send_message(
-                    "This can only be used in a server.", ephemeral=True
+                    embed=discord.Embed(
+                        description="This can only be used in a server."
+                    ),
+                    ephemeral=True,
                 )
             target = member or interaction.user
             record = await get_user_record(interaction.guild.id, target.id)
@@ -757,11 +760,13 @@ class LevelSystem(commands.Cog):
             logging.error(f"/level profile failed: {e}")
             try:
                 await interaction.response.send_message(
-                    "Failed to fetch profile.", ephemeral=True
+                    embed=discord.Embed(description="Failed to fetch profile."),
+                    ephemeral=True,
                 )
             except discord.InteractionResponded:
                 await interaction.followup.send(
-                    "Failed to fetch profile.", ephemeral=True
+                    embed=discord.Embed(description="Failed to fetch profile."),
+                    ephemeral=True,
                 )
 
     @group.command(name="leaderboard", description="Show the server leaderboard.")
@@ -769,7 +774,10 @@ class LevelSystem(commands.Cog):
         try:
             if not interaction.guild:
                 return await interaction.response.send_message(
-                    "This can only be used in a server.", ephemeral=True
+                    embed=discord.Embed(
+                        description="This can only be used in a server."
+                    ),
+                    ephemeral=True,
                 )
             view = LeaderboardView(self, interaction.guild, per_page=10)
             # Initial render
@@ -794,11 +802,13 @@ class LevelSystem(commands.Cog):
             logging.error(f"/level leaderboard failed: {e}")
             try:
                 await interaction.response.send_message(
-                    "Failed to fetch leaderboard.", ephemeral=True
+                    embed=discord.Embed(description="Failed to fetch leaderboard."),
+                    ephemeral=True,
                 )
             except discord.InteractionResponded:
                 await interaction.followup.send(
-                    "Failed to fetch leaderboard.", ephemeral=True
+                    embed=discord.Embed(description="Failed to fetch leaderboard."),
+                    ephemeral=True,
                 )
 
     # ==============================================================================
@@ -825,7 +835,8 @@ class LevelSystem(commands.Cog):
     async def cfg_show(self, interaction: discord.Interaction):
         if not interaction.guild:
             return await interaction.response.send_message(
-                "Server only.", ephemeral=True
+                embed=discord.Embed(description="Server only."),
+                ephemeral=True,
             )
         s = await get_settings(interaction.guild.id)
         ignored = await list_ignored_channels(interaction.guild.id)
@@ -887,13 +898,19 @@ class LevelSystem(commands.Cog):
     ):
         if xp_max < xp_min:
             return await interaction.response.send_message(
-                "xp_max must be greater than or equal to xp_min.", ephemeral=True
+                embed=discord.Embed(
+                    description="xp_max must be greater than or equal to xp_min."
+                ),
+                ephemeral=True,
             )
         await update_settings(
             interaction.guild.id, xp_min=int(xp_min), xp_max=int(xp_max)
         )
         await interaction.response.send_message(
-            f"XP range set to {xp_min}-{xp_max}.", ephemeral=True
+            embed=discord.Embed(
+                description=f"XP range set to {xp_min}-{xp_max}."
+            ),
+            ephemeral=True,
         )
 
     @config.command(
@@ -908,7 +925,10 @@ class LevelSystem(commands.Cog):
     ):
         await update_settings(interaction.guild.id, cooldown_seconds=int(seconds))
         await interaction.response.send_message(
-            f"Cooldown set to {seconds} seconds.", ephemeral=True
+            embed=discord.Embed(
+                description=f"Cooldown set to {seconds} seconds."
+            ),
+            ephemeral=True,
         )
 
     @config.command(name="setmultiplier", description="Set global XP multiplier.")
@@ -921,7 +941,10 @@ class LevelSystem(commands.Cog):
     ):
         await update_settings(interaction.guild.id, multiplier=float(multiplier))
         await interaction.response.send_message(
-            f"Global multiplier set to {multiplier}.", ephemeral=True
+            embed=discord.Embed(
+                description=f"Global multiplier set to {multiplier}."
+            ),
+            ephemeral=True,
         )
 
     @config.command(
@@ -936,7 +959,10 @@ class LevelSystem(commands.Cog):
     ):
         await update_settings(interaction.guild.id, min_chars=int(min_chars))
         await interaction.response.send_message(
-            f"Minimum characters set to {min_chars}.", ephemeral=True
+            embed=discord.Embed(
+                description=f"Minimum characters set to {min_chars}."
+            ),
+            ephemeral=True,
         )
 
     @config.command(
@@ -959,7 +985,11 @@ class LevelSystem(commands.Cog):
             mentions_bonus=int(mentions_bonus),
         )
         await interaction.response.send_message(
-            f"Bonuses updated. Attachments: {attachments_bonus}, Mentions: {mentions_bonus}.",
+            embed=discord.Embed(
+                description=(
+                    f"Bonuses updated. Attachments: {attachments_bonus}, Mentions: {mentions_bonus}."
+                )
+            ),
             ephemeral=True,
         )
 
@@ -977,7 +1007,10 @@ class LevelSystem(commands.Cog):
             interaction.guild.id, threads_multiplier=float(threads_multiplier)
         )
         await interaction.response.send_message(
-            f"Threads multiplier set to {threads_multiplier}.", ephemeral=True
+            embed=discord.Embed(
+                description=f"Threads multiplier set to {threads_multiplier}."
+            ),
+            ephemeral=True,
         )
 
     @config.command(name="ignorebots", description="Toggle ignoring bot messages.")
@@ -986,7 +1019,10 @@ class LevelSystem(commands.Cog):
     async def cfg_ignorebots(self, interaction: discord.Interaction, enabled: bool):
         await update_settings(interaction.guild.id, ignore_bots=1 if enabled else 0)
         await interaction.response.send_message(
-            f"Ignore bots set to {enabled}.", ephemeral=True
+            embed=discord.Embed(
+                description=f"Ignore bots set to {enabled}."
+            ),
+            ephemeral=True,
         )
 
     # ----- curve settings -----
@@ -1017,7 +1053,11 @@ class LevelSystem(commands.Cog):
             curve_b=int(curve_b),
         )
         await interaction.response.send_message(
-            f"Curve set to {ct}. base_xp={base_xp}, a={curve_a}, b={curve_b}.",
+            embed=discord.Embed(
+                description=(
+                    f"Curve set to {ct}. base_xp={base_xp}, a={curve_a}, b={curve_b}."
+                )
+            ),
             ephemeral=True,
         )
 
@@ -1032,7 +1072,10 @@ class LevelSystem(commands.Cog):
             interaction.guild.id, announce_level_up=1 if enabled else 0
         )
         await interaction.response.send_message(
-            f"Level up announcements set to {enabled}.", ephemeral=True
+            embed=discord.Embed(
+                description=f"Level up announcements set to {enabled}."
+            ),
+            ephemeral=True,
         )
 
     @config.command(
@@ -1052,11 +1095,18 @@ class LevelSystem(commands.Cog):
         await update_settings(interaction.guild.id, announce_channel_id=ch_id)
         if channel:
             await interaction.response.send_message(
-                f"Announcements will be posted in {channel.mention}.", ephemeral=True
+                embed=discord.Embed(
+                    description=f"Announcements will be posted in {channel.mention}."
+                ),
+                ephemeral=True,
             )
         else:
             await interaction.response.send_message(
-                "Announcement channel cleared. Will post in the same channel as the level up event.",
+                embed=discord.Embed(
+                    description=(
+                        "Announcement channel cleared. Will post in the same channel as the level up event."
+                    )
+                ),
                 ephemeral=True,
             )
 
@@ -1069,7 +1119,10 @@ class LevelSystem(commands.Cog):
     ):
         await add_ignored_channel(interaction.guild.id, channel.id)
         await interaction.response.send_message(
-            f"Added {channel.mention} to ignored channels.", ephemeral=True
+            embed=discord.Embed(
+                description=f"Added {channel.mention} to ignored channels."
+            ),
+            ephemeral=True,
         )
 
     @config.command(
@@ -1082,7 +1135,10 @@ class LevelSystem(commands.Cog):
     ):
         await remove_ignored_channel(interaction.guild.id, channel.id)
         await interaction.response.send_message(
-            f"Removed {channel.mention} from ignored channels.", ephemeral=True
+            embed=discord.Embed(
+                description=f"Removed {channel.mention} from ignored channels."
+            ),
+            ephemeral=True,
         )
 
     @config.command(name="ignorelist", description="List ignored channels.")
@@ -1091,14 +1147,18 @@ class LevelSystem(commands.Cog):
         ch_ids = await list_ignored_channels(interaction.guild.id)
         if not ch_ids:
             return await interaction.response.send_message(
-                "No ignored channels.", ephemeral=True
+                embed=discord.Embed(description="No ignored channels."),
+                ephemeral=True,
             )
         mentions = []
         for cid in ch_ids:
             ch = interaction.guild.get_channel(cid)
             mentions.append(ch.mention if ch else f"`{cid}`")
         await interaction.response.send_message(
-            "Ignored channels:\n" + ", ".join(mentions), ephemeral=True
+            embed=discord.Embed(
+                description="Ignored channels:\n" + ", ".join(mentions)
+            ),
+            ephemeral=True,
         )
 
     # ----- blacklist roles -----
@@ -1112,7 +1172,10 @@ class LevelSystem(commands.Cog):
     ):
         await add_blacklisted_role(interaction.guild.id, role.id)
         await interaction.response.send_message(
-            f"Added {role.mention} to blacklisted roles.", ephemeral=True
+            embed=discord.Embed(
+                description=f"Added {role.mention} to blacklisted roles."
+            ),
+            ephemeral=True,
         )
 
     @config.command(
@@ -1125,7 +1188,10 @@ class LevelSystem(commands.Cog):
     ):
         await remove_blacklisted_role(interaction.guild.id, role.id)
         await interaction.response.send_message(
-            f"Removed {role.mention} from blacklisted roles.", ephemeral=True
+            embed=discord.Embed(
+                description=f"Removed {role.mention} from blacklisted roles."
+            ),
+            ephemeral=True,
         )
 
     @config.command(name="blacklistlist", description="List blacklisted roles.")
@@ -1134,14 +1200,18 @@ class LevelSystem(commands.Cog):
         roles = await list_blacklisted_roles(interaction.guild.id)
         if not roles:
             return await interaction.response.send_message(
-                "No blacklisted roles.", ephemeral=True
+                embed=discord.Embed(description="No blacklisted roles."),
+                ephemeral=True,
             )
         mentions = []
         for rid in roles:
             r = interaction.guild.get_role(rid)
             mentions.append(r.mention if r else f"`{rid}`")
         await interaction.response.send_message(
-            "Blacklisted roles:\n" + ", ".join(mentions), ephemeral=True
+            embed=discord.Embed(
+                description="Blacklisted roles:\n" + ", ".join(mentions)
+            ),
+            ephemeral=True,
         )
 
     # ----- role rewards -----
@@ -1162,12 +1232,16 @@ class LevelSystem(commands.Cog):
         try:
             await set_role_reward(interaction.guild.id, int(level), role.id)
             await interaction.followup.send(
-                f"Set reward for level {level} to {role.mention}.", ephemeral=True
+                embed=discord.Embed(
+                    description=f"Set reward for level {level} to {role.mention}."
+                ),
+                ephemeral=True,
             )
         except Exception as e:
             logging.error(f"rewardset failed: {e}")
             await interaction.followup.send(
-                "Failed to set role reward.", ephemeral=True
+                embed=discord.Embed(description="Failed to set role reward."),
+                ephemeral=True,
             )
 
     @config.command(
@@ -1184,12 +1258,16 @@ class LevelSystem(commands.Cog):
         try:
             await remove_role_reward(interaction.guild.id, int(level))
             await interaction.followup.send(
-                f"Removed reward for level {level}.", ephemeral=True
+                embed=discord.Embed(
+                    description=f"Removed reward for level {level}."
+                ),
+                ephemeral=True,
             )
         except Exception as e:
             logging.error(f"rewardremove failed: {e}")
             await interaction.followup.send(
-                "Failed to remove role reward.", ephemeral=True
+                embed=discord.Embed(description="Failed to remove role reward."),
+                ephemeral=True,
             )
 
     @config.command(name="rewardlist", description="List all role rewards.")
@@ -1198,7 +1276,8 @@ class LevelSystem(commands.Cog):
         rows = await list_role_rewards(interaction.guild.id)
         if not rows:
             return await interaction.response.send_message(
-                "No role rewards set.", ephemeral=True
+                embed=discord.Embed(description="No role rewards set."),
+                ephemeral=True,
             )
         lines: List[str] = []
         for r in rows:
@@ -1211,7 +1290,10 @@ class LevelSystem(commands.Cog):
                 lines.append(f"Level {lvl} → `{role_id}`")
 
         await interaction.response.send_message(
-            "Role rewards:\n" + "\n".join(lines), ephemeral=True
+            embed=discord.Embed(
+                description="Role rewards:\n" + "\n".join(lines)
+            ),
+            ephemeral=True,
         )
 
     # ----- user management -----
@@ -1236,7 +1318,10 @@ class LevelSystem(commands.Cog):
                     names.append(f"Level {lvl}: {role.mention}")
             if names:
                 msg += "\nRewards granted:\n" + "\n".join(names)
-        await interaction.response.send_message(msg, ephemeral=True)
+        await interaction.response.send_message(
+            embed=discord.Embed(description=msg),
+            ephemeral=True,
+        )
 
     @config.command(
         name="setlevel",
@@ -1274,7 +1359,9 @@ class LevelSystem(commands.Cog):
             )
             conn.commit()
         await interaction.response.send_message(
-            f"Set {member.mention} to level {level_value} with XP {req}.",
+            embed=discord.Embed(
+                description=f"Set {member.mention} to level {level_value} with XP {req}."
+            ),
             ephemeral=True,
         )
 
@@ -1291,7 +1378,10 @@ class LevelSystem(commands.Cog):
             )
             conn.commit()
         await interaction.response.send_message(
-            f"Reset {member.mention}'s XP and level.", ephemeral=True
+            embed=discord.Embed(
+                description=f"Reset {member.mention}'s XP and level."
+            ),
+            ephemeral=True,
         )
 
     @config.command(
@@ -1304,7 +1394,10 @@ class LevelSystem(commands.Cog):
     ):
         if not confirm:
             return await interaction.response.send_message(
-                "You must confirm by setting confirm=True.", ephemeral=True
+                embed=discord.Embed(
+                    description="You must confirm by setting confirm=True."
+                ),
+                ephemeral=True,
             )
         gid = interaction.guild.id
         async with _db_lock:
@@ -1315,7 +1408,10 @@ class LevelSystem(commands.Cog):
             cursor.execute("DELETE FROM guild_settings WHERE guild_id = ?", (gid,))
             conn.commit()
         await interaction.response.send_message(
-            "All levelling data wiped for this server. Defaults will be recreated on next use.",
+            embed=discord.Embed(
+                description=
+                "All levelling data wiped for this server. Defaults will be recreated on next use."
+            ),
             ephemeral=True,
         )
 
@@ -1368,16 +1464,23 @@ class LevelSystem(commands.Cog):
             if idx == 0 and not interaction.response.is_done():
                 try:
                     await interaction.response.send_message(
-                        f"Curve: **{s['curve_type']}**\n```text\n{part}\n```",
+                        embed=discord.Embed(
+                            description=f"Curve: **{s['curve_type']}**\n```text\n{part}\n```"
+                        ),
                         ephemeral=True,
                     )
                 except discord.InteractionResponded:
                     await interaction.followup.send(
-                        f"Curve: **{s['curve_type']}**\n```text\n{part}\n```",
+                        embed=discord.Embed(
+                            description=f"Curve: **{s['curve_type']}**\n```text\n{part}\n```"
+                        ),
                         ephemeral=True,
                     )
             else:
-                await interaction.followup.send(f"```text\n{part}\n```", ephemeral=True)
+                await interaction.followup.send(
+                    embed=discord.Embed(description=f"```text\n{part}\n```"),
+                    ephemeral=True,
+                )
 
 
 # ======================================================================================
@@ -1390,7 +1493,8 @@ async def view_level_profile(interaction: discord.Interaction, member: discord.M
     try:
         if not interaction.guild:
             return await interaction.response.send_message(
-                "This can only be used in a server.", ephemeral=True
+                embed=discord.Embed(description="This can only be used in a server."),
+                ephemeral=True,
             )
         record = await get_user_record(interaction.guild.id, member.id)
         settings = await get_settings(interaction.guild.id)
@@ -1428,10 +1532,14 @@ async def view_level_profile(interaction: discord.Interaction, member: discord.M
         logging.error(f"context profile failed: {e}")
         try:
             await interaction.response.send_message(
-                "Failed to fetch profile.", ephemeral=True
+                embed=discord.Embed(description="Failed to fetch profile."),
+                ephemeral=True,
             )
         except discord.InteractionResponded:
-            await interaction.followup.send("Failed to fetch profile.", ephemeral=True)
+            await interaction.followup.send(
+                embed=discord.Embed(description="Failed to fetch profile."),
+                ephemeral=True,
+            )
 
 
 # Store a reference so we can remove it on teardown if needed

--- a/cogs/StickyMessages.py
+++ b/cogs/StickyMessages.py
@@ -172,9 +172,15 @@ class StickyFormatSelect(discord.ui.Select):
                 StickyModal(interaction.client, self.sticky_cog, "normal", None)
             )
         else:  # embed
-            view = StickyColourPickView(interaction.client, self.sticky_cog, interaction.channel, "embed")
+            view = StickyColourPickView(
+                interaction.client, self.sticky_cog, interaction.channel, "embed"
+            )
             await interaction.response.send_message(
-                "Choose a colour for your sticky embed:", view=view, ephemeral=True
+                embed=discord.Embed(
+                    description="Choose a colour for your sticky embed:"
+                ),
+                view=view,
+                ephemeral=True,
             )
         audit_log(f"{interaction.user} selected sticky format '{choice}'.")
 
@@ -473,8 +479,14 @@ class Sticky(commands.Cog):
     @app_commands.command(name="setsticky", description="Set a sticky message in the channel.")
     async def set_sticky(self, interaction: discord.Interaction):
         view = StickyFormatView(self)
-        await interaction.response.send_message("Choose the sticky message format:", view=view, ephemeral=True)
-        audit_log(f"{interaction.user} invoked /setsticky in channel #{interaction.channel.name}.")
+        await interaction.response.send_message(
+            embed=discord.Embed(description="Choose the sticky message format:"),
+            view=view,
+            ephemeral=True,
+        )
+        audit_log(
+            f"{interaction.user} invoked /setsticky in channel #{interaction.channel.name}."
+        )
 
     @app_commands.command(name="removesticky", description="Remove the sticky message in the channel.")
     async def remove_sticky(self, interaction: discord.Interaction):


### PR DESCRIPTION
## Summary
- send embed-based prompts for custom embed and sticky message setup
- convert levelling responses and errors to embeds

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c591486de4832e82243ca1eeffe455